### PR TITLE
feat:

### DIFF
--- a/accounts/permission.py
+++ b/accounts/permission.py
@@ -1,0 +1,29 @@
+from rest_framework import permissions
+
+
+class IsOwner(permissions.BasePermission):
+    """
+    본인만 접근 가능
+    """
+    def has_object_permission(self, request, view, obj):
+        if request.user.is_authenticated:                       # 로그인 여부 확인
+            if hasattr(obj, request):                           # 본인이면 권한 부여
+                return obj.username == request.user.username
+            else:
+                return False
+        else:
+            return False
+
+
+class IsOwnerOrStaff(permissions.BasePermission):
+    """
+    로그인한 본인과 운영자 접근 가능
+    """
+    def has_object_permission(self, request, view, obj):
+        if request.user.is_authenticated:                       # 로그인 여부 확인
+            if request.user.is_staff:                           # 운영자이면 권한 부여
+                return True
+            elif hasattr(obj, request):                         # 본인이면 권한 부여
+                return obj.username == request.username
+        else:
+            return False

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -42,6 +42,10 @@ class RegisterSerializer(serializers.ModelSerializer):
 
 
 class LoginSerializer(serializers.Serializer):
+    """
+    로그인
+    로그인과 함께 토큰 생성
+    """
     username = serializers.CharField(required=True)
     password = serializers.CharField(required=True, write_only=True)
 
@@ -60,19 +64,37 @@ class LoginSerializer(serializers.Serializer):
         )
 
 
+class UsersSerializer(serializers.ModelSerializer):
+    """
+    유저 목록 조회
+    """
+    class Meta:
+        model = User
+        fields= ['id', 'username', 'age', 'gender', 'phone_number', 'is_active', 'is_staff']
+
+
 class UserSerializer(serializers.ModelSerializer):
+    """
+    단일 유저 조회와 수정
+    """
     class Meta:
         model = User
         fields = ['id', 'username', 'password', 'age', 'gender', 'phone_number']
 
 
 class MakeStaffSerializer(serializers.ModelSerializer):
+    """
+    is_staff 변경
+    """
     class Meta:
         model = User
         fields = ['is_staff']
 
 
 class SoftDeleteSerializer(serializers.ModelSerializer):
+    """
+    is_active 변경
+    """
     class Meta:
         model = User
         fields = ['is_active']

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,12 +1,13 @@
 from django.urls import path
-from .views import RegisterAPI, LoginAPI, AccountAPI, MakeStaffAPI, SoftDeleteAPI
+from .views import RegisterAPI, LoginAPI, AccountListAPI, AccountDetailAPI, MakeStaffAPI, SoftDeleteAPI
 
 app_name = 'accounts'
 
 urlpatterns = [
     path('register/', RegisterAPI.as_view()),
     path('login/', LoginAPI.as_view()),
-    path('<str:username>/', AccountAPI.as_view()),
+    path('list/', AccountListAPI.as_view()),
+    path('<str:username>/', AccountDetailAPI.as_view()),
     path('make_staff/<str:username>/', MakeStaffAPI.as_view()),
     path('delete/<str:username>/', SoftDeleteAPI.as_view()),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,14 +1,20 @@
 from rest_framework import generics, status
+from rest_framework.permissions import AllowAny, IsAuthenticated, IsAdminUser
 from rest_framework.response import Response
+from .permission import IsOwner, IsOwnerOrStaff
 from .models import User
-from .serializers import RegisterSerializer, UserSerializer, MakeStaffSerializer, SoftDeleteSerializer, LoginSerializer
+from .serializers import RegisterSerializer, UsersSerializer, UserSerializer, \
+    MakeStaffSerializer, SoftDeleteSerializer, LoginSerializer
 
 
 class RegisterAPI(generics.CreateAPIView):
     """
     회원가입 API
+    누구나 접근 가능
     회원 생성과 토큰 생성
     """
+    permission_classes = [AllowAny]
+
     queryset = User.objects.all()
     serializer_class = RegisterSerializer
 
@@ -16,9 +22,12 @@ class RegisterAPI(generics.CreateAPIView):
 class LoginAPI(generics.GenericAPIView):
     """
     로그인 API
+    누구나 접근 가능
     username, password, token으로 유효성 판단
     token을 리턴함
     """
+    permission_classes = [AllowAny]
+
     serializer_class = LoginSerializer
 
     def post(self, request):
@@ -28,10 +37,24 @@ class LoginAPI(generics.GenericAPIView):
         return Response({'token': token.key}, status=status.HTTP_200_OK)
 
 
-class AccountAPI(generics.RetrieveUpdateAPIView):
+class AccountListAPI(generics.ListAPIView):
     """
-    회원 조회, 회원 정보 수정 API
+    회원 목록 조회
+    관리자만 접근 가능(is_staff==True)
     """
+    permission_classes = [IsAdminUser]
+
+    queryset = User.objects.all()
+    serializer_class = UsersSerializer
+
+
+class AccountDetailAPI(generics.RetrieveUpdateAPIView):
+    """
+    단일 회원 조회, 회원 정보 수정 API
+    본인만 접근 가능
+    """
+    permission_classes = [IsOwner]
+
     queryset = User.objects.all()
     serializer_class = UserSerializer
     lookup_field = 'username'
@@ -40,8 +63,11 @@ class AccountAPI(generics.RetrieveUpdateAPIView):
 class MakeStaffAPI(generics.UpdateAPIView):
     """
     관리자 임명 API
+    관리자만 접근 가능(is_staff==True)
     is_staff를 변경
     """
+    permission_classes = [IsAdminUser]
+
     queryset = User.objects.all()
     serializer_class = MakeStaffSerializer
     lookup_field = 'username'
@@ -50,8 +76,11 @@ class MakeStaffAPI(generics.UpdateAPIView):
 class SoftDeleteAPI(generics.UpdateAPIView):
     """
     sof-delete를 위한 API
+    관리자와 본인 접근 가능
     is_active를 변경
     """
+    permission_classes = [IsOwnerOrStaff]
+
     queryset = User.objects.all()
     serializer_class = SoftDeleteSerializer
     lookup_field = 'username'

--- a/config/urls.py
+++ b/config/urls.py
@@ -18,5 +18,6 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('accounts/', include('accounts.urls'))
+    path('accounts/', include('accounts.urls')),
+    path('api_auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]


### PR DESCRIPTION
- accounts.views에 AccountListAPI(유저 목록 조회) 추가(관리자만 접근)
- accounts.permission.py 추가(로그인 여부, 본인 여부, 권리자 여부에 따른 권한)
- accounts.urls.py 수정

### :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

### :: 구현 목표 
- accounts API에 대한 접근 권한 부여
- 회원 목록 조회

<br />

### :: 구현 사항
1. 
- 회원 목록 조회(관리자만 가능)
-  permission.py에 권한 추가(본인만 접근, 본인과 관리자 접근)
- accounts.views.py의 API에 권한 추가
- acccounts.urls.py 수정