### PR TITLE
Fix : 각 게시판 API TESTCASE 오류 해결

### DIFF
--- a/boards/tests/test_board.py
+++ b/boards/tests/test_board.py
@@ -15,7 +15,7 @@ class FreeboardViewSetTest(APITestCase):
         self.user = User.objects.create_user(
             username='user', password='0000', age=25, gender='F', phone_number='010-1234-5678'
         )
-        self.client.login(username='user', password='0000')
+        self.client.force_authenticate(self.user)
         self.freeboard = Freeboard.objects.create(
             title='자유게시판 제목 테스트 첫번째입니다.', content='자유게시판 본문 테스트 첫번째입니다.', author_id=self.user
         )
@@ -66,7 +66,7 @@ class NoticeViewSetTest(APITestCase):
         self.staff = User.objects.create_user(
             username='staff', password='0000', age=25, gender='F', phone_number='010-1234-5678', is_staff= True
         )
-        self.client.login(username='staff', password='0000')
+        self.client.force_authenticate(self.staff)
         self.notice = Notice.objects.create(
             title='공지사항 제목 테스트 첫번째입니다.', content='공지사항 본문 테스트 첫번째입니다.', author_id=self.staff
         )
@@ -117,7 +117,7 @@ class StaffboardViewSetTest(APITestCase):
         self.staff = User.objects.create_user(
             username='staff', password='0000', age=25, gender='F', phone_number='010-1234-5678', is_staff=True
         )
-        self.client.login(username='staff', password='0000')
+        self.client.force_authenticate(self.staff)
         self.staffboard = Staffboard.objects.create(
             title='운영자 게시판 제목 테스트 첫번째입니다.', content='운영자 게시판 본문 테스트 첫번째입니다.', author_id=self.staff
         )


### PR DESCRIPTION
- user 인증 실패로 HTTP 401를 해결하기 위해 force_authenticate 이용하여 강제인증

### :: 최근 작업 주제
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

### :: 구현 목표 
-  각 게시판 API TEST CASE 정상작동

<br />

### :: 구현 사항
1.  Token을 이용한 User 인증을 구현하기보다 force_authenticate를 이용한 강제 인증


### :: 특이 사항
